### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -9,7 +9,7 @@
         <div class="modal-content glass-panel border-nordic shadow-lg">
             <div class="modal-header border-0 pb-0">
                 <h5 class="modal-title fw-bold" id="toolTitle"><svg style="width:16px;height:16px;margin-right:8px;fill:#ffc107" viewBox="0 0 512 512"><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>Tool</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" data-tippy-content="Close modal"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" data-tippy-content="Close modal" aria-label="Close modal"></button>
             </div>
             <div class="modal-body pt-3" id="toolBody">
                 <!-- Content injected via JS -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -155,7 +155,7 @@
             <div class="d-flex align-items-center gap-2">
                 <svg style="width:12px;height:12px;fill:currentColor;opacity:0.2" viewBox="0 0 320 512"><path d="M40 352a40 40 0 1 0 0 80 40 40 0 1 0 0-80zm0-160a40 40 0 1 0 0 80 40 40 0 1 0 0-80zm0-160a40 40 0 1 0 0 80 40 40 0 1 0 0-80zm160 320a40 40 0 1 0 0 80 40 40 0 1 0 0-80zm0-160a40 40 0 1 0 0 80 40 40 0 1 0 0-80zm0-160a40 40 0 1 0 0 80 40 40 0 1 0 0-80z"/></svg>
             </div>
-            <button class="btn btn-link btn-sm text-white p-0" onclick="this.closest('.result-card').remove()" data-tippy-content="Close widget">
+            <button class="btn btn-link btn-sm text-white p-0" onclick="this.closest('.result-card').remove()" data-tippy-content="Close widget" aria-label="Close widget">
                 <svg style="width:12px;height:12px;fill:currentColor" viewBox="0 0 384 512"><path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/></svg>
             </button>
         </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the icon-only close buttons in the result card widget (`templates/index.html`) and the tool modal (`templates/footer.html`).

🎯 **Why:** Icon-only buttons without accessible names cannot be understood by screen readers. The `data-tippy-content` tooltips provide visual context on hover, but an explicit `aria-label` is required for assistive technologies to announce the button's purpose correctly.

♿ **Accessibility:** Enhances screen reader compatibility by explicitly describing the "Close widget" and "Close modal" actions.

📸 **Before/After:** No visual changes, purely an accessibility enhancement. Keyboard navigation and screen reader experience are significantly improved.

---
*PR created automatically by Jules for task [5730242792080930397](https://jules.google.com/task/5730242792080930397) started by @arumes31*