### PR TITLE
🧪 Add test for WHOIS RDAP fallback

### DIFF
--- a/internal/service/whois_test.go
+++ b/internal/service/whois_test.go
@@ -86,7 +86,11 @@ func TestRDAPLookup(t *testing.T) {
 
 func TestWhois_Mocked(t *testing.T) {
 	oldWhois := WhoisFunc
-	defer func() { WhoisFunc = oldWhois }()
+	oldRdap := RdapLookupFunc
+	defer func() {
+		WhoisFunc = oldWhois
+		RdapLookupFunc = oldRdap
+	}()
 
 	t.Run("Error Response Fallback", func(t *testing.T) {
 		WhoisFunc = func(target string, query ...string) (string, error) {
@@ -150,6 +154,20 @@ func TestWhois_Mocked(t *testing.T) {
 		}
 		if !strings.Contains(info.Raw, "Line 1") {
 			t.Error("Expected Line 1 to be present")
+		}
+	})
+
+	t.Run("RDAP Fallback", func(t *testing.T) {
+		WhoisFunc = func(target string, query ...string) (string, error) {
+			return "", fmt.Errorf("all whois failed")
+		}
+		RdapLookupFunc = func(target string) (string, error) {
+			return "Mock RDAP Data", nil
+		}
+		res := Whois("test.com")
+		info, ok := res.(WhoisInfo)
+		if !ok || !strings.Contains(info.Raw, "Mock RDAP Data") {
+			t.Errorf("Expected RDAP fallback to succeed, got %v", res)
 		}
 	})
 }


### PR DESCRIPTION
🎯 **What:** Add missing test coverage for the RDAP fallback mechanism in the WHOIS service.
📊 **Coverage:** A new subtest `RDAP Fallback` was added to `TestWhois_Mocked` in `internal/service/whois_test.go`. This subtest verifies that when standard WHOIS lookups (including TLD-specific and IANA fallbacks) fail, the system correctly falls back to RDAP.
✨ **Result:** Improved test reliability by ensuring the modern RDAP fallback path is verified.

---
*PR created automatically by Jules for task [9250136578642628344](https://jules.google.com/task/9250136578642628344) started by @arumes31*