### PR TITLE
🔒 Replace insecure math/rand with crypto/rand for WHOIS servers

### DIFF
--- a/internal/service/whois.go
+++ b/internal/service/whois.go
@@ -1,10 +1,10 @@
 package service
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strings"
-	"time"
 	"whois/internal/utils"
 
 	"github.com/likexian/whois"
@@ -74,8 +74,14 @@ func Whois(target string) interface{} {
 		if servers, ok := fallbacks[tld]; ok {
 			shuffled := make([]string, len(servers))
 			copy(shuffled, servers)
-			r := rand.New(rand.NewSource(time.Now().UnixNano()))
-			r.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+			for i := len(shuffled) - 1; i > 0; i-- {
+				n, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+				if err != nil {
+					continue
+				}
+				j := int(n.Int64())
+				shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+			}
 
 			for _, s := range shuffled {
 				rRaw, rErr := WhoisFunc(target, s)


### PR DESCRIPTION
This PR addresses a security vulnerability where `math/rand` was used for shuffling the list of WHOIS servers, making the order predictable. It replaces the insecure RNG with `crypto/rand`.

### Changes:
- Modified `internal/service/whois.go` to use `crypto/rand.Int` for shuffling.
- Updated imports to remove `math/rand` and `time`, and added `crypto/rand` and `math/big`.
- Implemented a manual Fisher-Yates shuffle since `crypto/rand` doesn't provide a built-in `Shuffle` method.

### Verification:
- Verified that the code compiles successfully with `go build ./...`.
- Confirmed the use of `crypto/rand` via manual inspection and code review.
- Unit tests were attempted but timed out due to environmental constraints; however, the logic was reviewed and confirmed to be correct.

---
*PR created automatically by Jules for task [9666201112333547927](https://jules.google.com/task/9666201112333547927) started by @arumes31*