### PR TITLE
🧪 Add missing error test for invalid target in HTTPInfo

### DIFF
--- a/internal/service/http_test.go
+++ b/internal/service/http_test.go
@@ -140,3 +140,10 @@ func TestGetHTTPInfo_InvalidURL(t *testing.T) {
 		t.Error("Expected error for invalid URL hostname")
 	}
 }
+
+func TestGetHTTPInfo_InvalidTarget(t *testing.T) {
+	info := GetHTTPInfo(context.Background(), "invalidhost")
+	if info.Error != "invalid target host" {
+		t.Errorf("Expected 'invalid target host' error, got '%s'", info.Error)
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error test for invalid targets in `GetHTTPInfo`.
📊 **Coverage:** A new test case `TestGetHTTPInfo_InvalidTarget` has been added to `internal/service/http_test.go`, covering the branch where `utils.IsValidTarget(host)` returns false.
✨ **Result:** Increased reliability and coverage of the error handling logic in the HTTP info service.

---
*PR created automatically by Jules for task [15717411686042881617](https://jules.google.com/task/15717411686042881617) started by @arumes31*