### PR TITLE
🧪 [testing improvement] IANA fallback error paths

### DIFF
--- a/internal/service/whois_test.go
+++ b/internal/service/whois_test.go
@@ -152,4 +152,55 @@ func TestWhois_Mocked(t *testing.T) {
 			t.Error("Expected Line 1 to be present")
 		}
 	})
+
+	t.Run("IANA Lookup Failure Fallback to RDAP", func(t *testing.T) {
+		oldRdap := RdapLookupFunc
+		defer func() { RdapLookupFunc = oldRdap }()
+
+		WhoisFunc = func(target string, query ...string) (string, error) {
+			if len(query) == 0 {
+				return "No whois server found", nil
+			}
+			if query[0] == "whois.iana.org" {
+				return "", fmt.Errorf("IANA connection error")
+			}
+			return "error", nil
+		}
+		RdapLookupFunc = func(target string) (string, error) {
+			return "Mock RDAP Data for IANA Failure", nil
+		}
+
+		res := Whois("test.com")
+		info, ok := res.(WhoisInfo)
+		if !ok || info.Raw != "Mock RDAP Data for IANA Failure" {
+			t.Errorf("Expected RDAP fallback on IANA failure, got %v", res)
+		}
+	})
+
+	t.Run("IANA Referred Server Failure Fallback to RDAP", func(t *testing.T) {
+		oldRdap := RdapLookupFunc
+		defer func() { RdapLookupFunc = oldRdap }()
+
+		WhoisFunc = func(target string, query ...string) (string, error) {
+			if len(query) == 0 {
+				return "No whois server found", nil
+			}
+			if query[0] == "whois.iana.org" {
+				return "whois: whois.nic.fail\nrefer: whois.nic.fail", nil
+			}
+			if query[0] == "whois.nic.fail" {
+				return "", fmt.Errorf("Referred server error")
+			}
+			return "error", nil
+		}
+		RdapLookupFunc = func(target string) (string, error) {
+			return "Mock RDAP Data for Referral Failure", nil
+		}
+
+		res := Whois("test.com")
+		info, ok := res.(WhoisInfo)
+		if !ok || info.Raw != "Mock RDAP Data for Referral Failure" {
+			t.Errorf("Expected RDAP fallback on referral failure, got %v", res)
+		}
+	})
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error path tests for the WHOIS IANA fallback mechanism.
📊 **Coverage:** What scenarios are now tested:
- IANA Lookup Failure: Verifies fallback to RDAP when `whois.iana.org` returns an error.
- Referred Server Failure: Verifies fallback to RDAP when the server referred by IANA returns an error.
✨ **Result:** The improvement in test coverage: Improved reliability and coverage of the WHOIS service's fallback logic.

---
*PR created automatically by Jules for task [3178060408480627422](https://jules.google.com/task/3178060408480627422) started by @arumes31*