### PR TITLE
🧪 Implement mock-based test for DownloadOUI error path

### DIFF
--- a/internal/service/mac.go
+++ b/internal/service/mac.go
@@ -19,6 +19,7 @@ var (
 	OUIPath        = "data/oui.txt"
 	TestMode       = false
 	UpdateInterval = 12 * time.Hour
+	MacHTTPClient  = &http.Client{Timeout: 5 * time.Minute}
 )
 
 func InitializeMACService() {
@@ -48,8 +49,7 @@ func InitializeMACService() {
 }
 
 func DownloadOUI() error {
-	client := &http.Client{Timeout: 5 * time.Minute}
-	resp, err := client.Get(OUIURL)
+	resp, err := MacHTTPClient.Get(OUIURL)
 	if err != nil {
 		return err
 	}

--- a/internal/service/mac_test.go
+++ b/internal/service/mac_test.go
@@ -131,6 +131,21 @@ func TestMACService(t *testing.T) {
 		}
 	})
 
+	t.Run("DownloadOUI_RequestError", func(t *testing.T) {
+		oldTransport := MacHTTPClient.Transport
+		defer func() { MacHTTPClient.Transport = oldTransport }()
+
+		MacHTTPClient.Transport = &mockErrorTransport{}
+
+		err := DownloadOUI()
+		if err == nil {
+			t.Fatalf("Expected error for network failure")
+		}
+		if !strings.Contains(err.Error(), "mock error") {
+			t.Errorf("Expected error message to contain 'mock error', got: %v", err)
+		}
+	})
+
 	t.Run("LookupMacVendor_API", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cleanPath := strings.ReplaceAll(r.URL.Path, ":", "")
@@ -237,4 +252,10 @@ func TestMACService(t *testing.T) {
 
 func TestLocalOUILookup(t *testing.T) {
 	// Wrapper for legacy if any, though subtests cover it.
+}
+
+type mockErrorTransport struct{}
+
+func (m *mockErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("mock error")
 }


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
This PR addresses an untested error path in the `DownloadOUI` function within `internal/service/mac.go`. Previously, the function used a local `http.Client`, making it difficult to simulate and test network failures.

### 📊 Coverage: What scenarios are now tested
- **`DownloadOUI_RequestError`**: A new test case that simulates a network-level error during the OUI database download using a mock `http.RoundTripper`. This verifies that the function correctly returns an error when the HTTP request fails.
- **Refactoring**: Introduced `MacHTTPClient` as a package-level variable to allow transport injection for testing purposes, following established patterns in the codebase (e.g., `GeoHTTPClient`).

### ✨ Result: The improvement in test coverage
- Improved reliability of the MAC service by ensuring error handling logic is explicitly tested.
- Better alignment with Go testing best practices by enabling mock-based HTTP testing.

---
*PR created automatically by Jules for task [7438943407435294642](https://jules.google.com/task/7438943407435294642) started by @arumes31*