### PR TITLE
ci: update Docker metadata action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
Updates docker/metadata-action from v5 to v6, the maintained Node.js 24 release, removing the post-merge GHCR workflow deprecation warning. The image build, Trivy scan, and push behavior is unchanged.